### PR TITLE
fix: lint always returns true

### DIFF
--- a/include/linter.hpp
+++ b/include/linter.hpp
@@ -46,7 +46,7 @@ inline bool lint(std::istream& is, std::ostream& os, const char* path = nullptr)
                << buf << std::endl;
         }
     }
-    return true;
+    return !has_error;
 }
 inline bool lint(std::istream& is, const char* path = nullptr) { return lint(is, std::cerr, path); }
 #endif  // UTF8_TO_WINDOWS31J_CVT_CHECKER_LINTER_HPP_

--- a/include/linter.hpp
+++ b/include/linter.hpp
@@ -1,0 +1,52 @@
+/*=============================================================================
+  Copyright (C) 2021 yumetodo <yume-wikijp@live.jp>
+  Distributed under the Boost Software License, Version 1.0.
+  (See https://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#ifndef UTF8_TO_WINDOWS31J_CVT_CHECKER_LINTER_HPP_
+#define UTF8_TO_WINDOWS31J_CVT_CHECKER_LINTER_HPP_
+#include "utf8_to_windows31j_cvt_checker.hpp"
+enum class ascii_color : int {
+    reset = 0,
+    black = 30,
+    red = 31,
+    green = 32,
+    yellow = 33,
+    blue = 34,
+    magenta = 35,
+    cyan = 36,
+    white = 37,
+    bright_black = 90,
+    bright_red = 91,
+    bright_green = 92,
+    bright_yellow = 93,
+    bright_blue = 94,
+    bright_magenta = 95,
+    bright_cyan = 96,
+    bright_white = 97,
+};
+inline std::ostream& operator<<(std::ostream& os, ascii_color c) {
+    return os << "\033[" << static_cast<int>(c) << 'm';
+}
+inline bool lint(std::istream& is, std::ostream& os, const char* path = nullptr) {
+    iconv_utf8_windows31j_cvt cvt;
+    std::size_t line{};
+    bool has_error = false;
+    for (std::string buf; std::getline(is, buf); ++line) {
+        try {
+            cvt(buf);
+        } catch (const std::runtime_error& er) {
+            if (!std::exchange(has_error, true)) {
+                os << ascii_color::bright_red << "invalid input(s) has detected. see blow:\n";
+                if (path) {
+                    os << ascii_color::reset << "In file " << path << '\n';
+                }
+            }
+            os << ascii_color::bright_cyan << "line " << line << ascii_color::reset << '\n'
+               << buf << std::endl;
+        }
+    }
+    return true;
+}
+inline bool lint(std::istream& is, const char* path = nullptr) { return lint(is, std::cerr, path); }
+#endif  // UTF8_TO_WINDOWS31J_CVT_CHECKER_LINTER_HPP_

--- a/include/utf8_to_windows31j_cvt_checker.hpp
+++ b/include/utf8_to_windows31j_cvt_checker.hpp
@@ -3,8 +3,8 @@
   Distributed under the Boost Software License, Version 1.0.
   (See https://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
-#ifndef UTF8_TO_WINDOWS31J_CVT_CHECKER_HPP_
-#define UTF8_TO_WINDOWS31J_CVT_CHECKER_HPP_
+#ifndef UTF8_TO_WINDOWS31J_CVT_CHECKER_UTF8_TO_WINDOWS31J_CVT_CHECKER_HPP_
+#define UTF8_TO_WINDOWS31J_CVT_CHECKER_UTF8_TO_WINDOWS31J_CVT_CHECKER_HPP_
 
 #include <iconv.h>
 
@@ -13,28 +13,6 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
-enum class ascii_color : int {
-    reset = 0,
-    black = 30,
-    red = 31,
-    green = 32,
-    yellow = 33,
-    blue = 34,
-    magenta = 35,
-    cyan = 36,
-    white = 37,
-    bright_black = 90,
-    bright_red = 91,
-    bright_green = 92,
-    bright_yellow = 93,
-    bright_blue = 94,
-    bright_magenta = 95,
-    bright_cyan = 96,
-    bright_white = 97,
-};
-inline std::ostream& operator<<(std::ostream& os, ascii_color c) {
-    return os << "\033[" << static_cast<int>(c) << 'm';
-}
 class iconv_utf8_windows31j_cvt {
 public:
     iconv_utf8_windows31j_cvt() {
@@ -92,4 +70,4 @@ private:
     }
     iconv_t cd;
 };
-#endif  // UTF8_TO_WINDOWS31J_CVT_CHECKER_HPP_
+#endif  // UTF8_TO_WINDOWS31J_CVT_CHECKER_UTF8_TO_WINDOWS31J_CVT_CHECKER_HPP_

--- a/src/utf8_to_windows31j_cvt_checker.cpp
+++ b/src/utf8_to_windows31j_cvt_checker.cpp
@@ -6,27 +6,7 @@
 #include <fstream>
 #include <iostream>
 #include <utf8_to_windows31j_cvt_checker.hpp>
-bool lint(std::istream& is, const char* path = nullptr) {
-    iconv_utf8_windows31j_cvt cvt;
-    std::size_t line{};
-    bool has_error = false;
-    for (std::string buf; std::getline(is, buf); ++line) {
-        try {
-            cvt(buf);
-        } catch (const std::runtime_error& er) {
-            if (!std::exchange(has_error, true)) {
-                std::cerr << ascii_color::bright_red
-                          << "invalid input(s) has detected. see blow:\n";
-                if (path) {
-                    std::cerr << ascii_color::reset << "In file " << path << '\n';
-                }
-            }
-            std::cerr << ascii_color::bright_cyan << "line " << line << ascii_color::reset << '\n'
-                      << buf << std::endl;
-        }
-    }
-    return true;
-}
+#include <linter.hpp>
 int main(int argc, char** argv) {
     if (argc == 1) {
         return lint(std::cin) ? 0 : 1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,8 @@ project(basic_test)
 # Source files
 #
 set(basic_test_src
-    "./test.cpp"
+    "./utf8_to_windows31j_cvt_checker_test.cpp"
+    "./linter_test.cpp"
 )
 
 #

--- a/test/linter_test.cpp
+++ b/test/linter_test.cpp
@@ -10,11 +10,11 @@ IUTEST(Linter, success) {
     std::stringstream iss;
     iss << reinterpret_cast<const char*>(u8"インストールされていません");
     std::ostringstream oss;
-    IUTEST_ASSERT_EQ(0, lint(iss, oss));
+    IUTEST_ASSERT_EQ(true, lint(iss, oss));
 }
 IUTEST(Linter, fail) {
     std::stringstream iss;
     iss << reinterpret_cast<const char*>(u8"アプリケーション");
     std::ostringstream oss;
-    IUTEST_ASSERT_EQ(1, lint(iss, oss));
+    IUTEST_ASSERT_EQ(false, lint(iss, oss));
 }

--- a/test/linter_test.cpp
+++ b/test/linter_test.cpp
@@ -1,0 +1,20 @@
+﻿/*=============================================================================
+  Copyright (C) 2021 yumetodo <yume-wikijp@live.jp>
+  Distributed under the Boost Software License, Version 1.0.
+  (See https://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+#include <iutest.hpp>
+#include <linter.hpp>
+#include <sstream>
+IUTEST(Linter, success) {
+    std::stringstream iss;
+    iss << reinterpret_cast<const char*>(u8"インストールされていません");
+    std::ostringstream oss;
+    IUTEST_ASSERT_EQ(0, lint(iss, oss));
+}
+IUTEST(Linter, fail) {
+    std::stringstream iss;
+    iss << reinterpret_cast<const char*>(u8"アプリケーション");
+    std::ostringstream oss;
+    IUTEST_ASSERT_EQ(1, lint(iss, oss));
+}

--- a/test/utf8_to_windows31j_cvt_checker_test.cpp
+++ b/test/utf8_to_windows31j_cvt_checker_test.cpp
@@ -8,13 +8,13 @@
 #endif
 #include <iutest.hpp>
 #include <utf8_to_windows31j_cvt_checker.hpp>
-IUTEST(Basic, sucess) {
+IUTEST(Cvt, success) {
     const char* ascii = "arikitari na sekai";
     iconv_utf8_windows31j_cvt cvt;
     IUTEST_ASSERT_EQ(ascii, cvt(ascii));
     IUTEST_ASSERT_NO_THROW(cvt(reinterpret_cast<const char*>(u8"インストールされていません")));
 }
-IUTEST(Basic, fail) {
+IUTEST(Cvt, fail) {
     iconv_utf8_windows31j_cvt cvt;
     IUTEST_ASSERT_THROW(
         cvt(reinterpret_cast<const char*>(u8"アプリケーション")), std::runtime_error);


### PR DESCRIPTION
`lint`関数が常に`true`を返しているが、`has_error`を用いて戻り値を決定するのが意図した挙動であった。

また、ファイルから読み取るときに、`lint`の戻り値を逆に判定していた。

ref:
- #1